### PR TITLE
Fix Contributor Covenant badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The removal of any publicly-visible memorial, monument, statue, or other notewor
 
 ## How do I contribute?
 
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](code_of_conduct.md)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
 
 ### What do I contribute?
 


### PR DESCRIPTION
The link, `code_of_conduct.md` , was lower case and causing a 404, this just capitalizes it to match the exact name.