### PR TITLE
Fix category on Franciss Scott Key statue and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Contributions of all sorts are needed: edits, new content, or even just comments
 
 ### I am not confident with Github and writing markdown
 
-At the top of this page, click "Issues". There, click the button that says "New Issue".
+At the top of this page, click [Issues](https://github.com/Gorcenski/whentheycamedown/issues). There, click the button that says [New Issue](https://github.com/Gorcenski/whentheycamedown/issues/new).
 
 In the textbox that appears, go ahead and enter your content, paste any links, whatever. I'll convert it into the required format to publish.
 
@@ -36,3 +36,6 @@ All content lives under `content/{LANGUAGE}/post`. To translate an English post 
 For example, to translate the Christopher Columbus in Richmond post, copy `content/english/post/columbus-rva.md` to `content/espanol/post/columbus-rva.md` and edit the content to español.
 
 If the language is not supported, e.g. German, then create `content/deutsch/post/columbus-rva.md` and translate the post. Then, update the `config.toml` file in the root directory to add deutsch support.
+
+### Categories and tags
+The categories inside each post can include one or more of the following: `["colonizers", "confederates", "racists", "rapists", "slavers", "war-criminals"]` and the following tags can include one or more of the following: `["municipal-action", "renaming", "direct-action", "private-action"]`. Other tags and categories can be added, but first raise an issue about it.

--- a/content/english/post/key-sf.md
+++ b/content/english/post/key-sf.md
@@ -6,7 +6,7 @@ date = "2020-06-19T21:00:00-07:00"
 title = "Francis Scott Key—San Francisco, CA"
 photo_credits = "Peter Chu"
 photo_source_url = "https://mobile.twitter.com/pcnotpc/status/1274207217588158464"
-categories = [ "slaver" ]
+categories = [ "slavers" ]
 tags = ["direct-action"]
 weight = 1
 +++


### PR DESCRIPTION
As far as I can tell, we dynamically create categories, but I found one case of "Slaver"/"Slavers" that was likely unintentional. In future, could create a Netlify UI that allows a drop down of pre-selected categories, so such mistakes are avoided in future