### PR TITLE
Add post template document

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In the textbox that appears, go ahead and enter your content, paste any links, w
 
 ### I am confident with Github and writing markdown
 
-Add a markdown post under `content/post`. Use previous posts as an example. For post date, try to get, as near as possible, the date and time the memorial was removed. Add photo credits, and try to provide many references, where possible.
+Add a markdown post under `content/post`. Copy template.md and use previous posts as an example. For post date, try to get, as near as possible, the date and time the memorial was removed. Add photo credits, and try to provide many references, where possible.
 
 Images go in `static/img`.
 

--- a/_template.md
+++ b/_template.md
@@ -11,6 +11,7 @@ photo_source_url = "(Article or social media source link)"
 categories = ["slavers"]
 <!--- Possible tags: municipal-action, renaming, direct-action, private-action -->
 tags = ["municipal-action"]
+subjects = ["Robert E. Lee"]
 weight = 1
 +++
 

--- a/template.md
+++ b/template.md
@@ -1,0 +1,25 @@
++++
+showonlyimage = true
+draft = false
+image = "img/(filename)"
+date = "2020-MM-DDT12:00:00-05:00"
+title = "(Statue Name), (Location), (Country)"
+photo_credits = ""
+photo_source_url = "(Article or social media source link)"
+<!--- REMOVE THESE COMMENTS BEFORE COMMITING -->
+<!--- Possible categories: colonizers, confederates, racists, rapists, slavers, war-criminals -->
+categories = ["slavers"]
+<!--- Possible tags: municipal-action, renaming, direct-action, private-action -->
+tags = ["municipal-action"]
+weight = 1
++++
+
+Short blurb on what was removed/renamed and where it happened
+
+<!--more-->
+
+Add additional information about the statue/site (who commissioned it, when it was created/established). Also add information about the person that was "honored", making sure to mark references correctly.[^1]
+
+#### References
+
+[^1]: [Example Reference](https://github.com/Gorcenski/whentheycamedown/blob/trunk/README.md)


### PR DESCRIPTION
No known issue open for this.

This creates a template markdown document that new contributors can easily copy and being filling in to help increase throughput converting from issues into markdown pages for public consumption.