### PR TITLE
Link to blog post for non-GH-confident volunteers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ At the top of this page, click [Issues](https://github.com/Gorcenski/whentheycam
 
 In the textbox that appears, go ahead and enter your content, paste any links, whatever. I'll convert it into the required format to publish.
 
+This [blog post](https://scholarslab.lib.virginia.edu/blog/participating-in-statue-removal-history-crowdsourcing/) goes into further detail about how to get involved if you're not comfortable with GitHub yet.
+
 ### I am confident with Github and writing markdown
 
 Add a markdown post under `content/post`. Use previous posts as an example. For post date, try to get, as near as possible, the date and time the memorial was removed. Add photo credits, and try to provide many references, where possible.


### PR DESCRIPTION
I wrote up a blog post with some help for folks who haven't used GitHub, or aren't super comfortable with it). If that's useful to have linked in the Readme, this PR adds a line under the "I am not confident" section linking to the post. No worries if it isn't useful!